### PR TITLE
Don't raise exception when using django-user-sessions middleware

### DIFF
--- a/oauth2client/contrib/django_util/__init__.py
+++ b/oauth2client/contrib/django_util/__init__.py
@@ -352,11 +352,14 @@ class OAuth2Settings(object):
                 'configured')
 
         if ('django.contrib.sessions.middleware.SessionMiddleware' not in
+                middleware_settings and
+                'user_sessions.middleware.SessionMiddleware' not in
                 middleware_settings):
             raise exceptions.ImproperlyConfigured(
                 'The Google OAuth2 Helper requires session middleware to '
                 'be installed. Edit your MIDDLEWARE_CLASSES or MIDDLEWARE '
                 'setting to include \'django.contrib.sessions.middleware.'
+                'SessionMiddleware\' or \'user_sessions.middleware.'
                 'SessionMiddleware\'.')
         (self.storage_model, self.storage_model_user_property,
          self.storage_model_credentials_property) = _get_storage_model()


### PR DESCRIPTION
@zgalant @john-kelly

We would like to install the django-user-sessions library to allow better management of concurrent logins, but the oauth2client library is hardcoded to raise an exception if `'django.contrib.sessions.middleware.SessionMiddleware'` isn’t included in the list of middleware.

I added another condition to not raise an `ImproperlyConfigured` exception if the middleware from django-user-sessions is included instead. I tested this with django-user-sessions, and it works well so far!

This would have no effect on oauth2client if we decide not to use django-user-sessions, so I think this is a safe change to make.

django-user-sessions homepage:
https://pypi.org/project/django-user-sessions/

Installation steps:
https://django-user-sessions.readthedocs.io/en/stable/installation.html